### PR TITLE
Message build test

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -31,18 +31,21 @@ def parse_msg(conn, msg, active_channels):
         conn.send("PONG :tmi.twitch.tv")
         return
 
-    username, message, channel = split_msg_data(msg)
+    # Check for more than one message per recv call
+    message_chunks = msg.split("\r\n")
+    for split_msg in message_chunks:
+        username, message, channel = split_msg_data(split_msg)
 
-    print(str(datetime.now()) + " " + str(channel) + " -- " + username + ": " + message.strip())
+        print(str(datetime.now()) + " : " + str(channel) + " -- " + username + ": " + message.strip())
 
-    # Match a greeting message
-    if re.match(REGEX_GREETING, message, re.IGNORECASE):
-        active_channels[channel].send_greeting(username)
+        # Match a greeting message
+        if re.match(REGEX_GREETING, message, re.IGNORECASE):
+            active_channels[channel].send_greeting(username)
 
-    # Match a gamerdeath message
-    elif message == "!gamerdeath":
-        active_channels[channel].send_gamerdeath()
-
+        # Match a gamerdeath message
+        elif message == "!gamerdeath":
+            active_channels[channel].send_gamerdeath()
+    
 def split_msg_data(msg):
     """Split out user, message and channel names from a receieved message
 

--- a/src/conn.py
+++ b/src/conn.py
@@ -66,7 +66,7 @@ class SocketConnection():
         """
         data = None
         try:
-            data = self._sock.recv(self._RX_BUF_SZ).decode("utf-8").strip()
+            data = self._sock.recv(self._RX_BUF_SZ).decode("utf-8", "ignore").strip()
         except socket.timeout:
             pass
         return data

--- a/src/conn.py
+++ b/src/conn.py
@@ -24,7 +24,7 @@ class SocketConnection():
     """Manages the socket connection"""
     def __init__(self):
         """Constructor."""
-        self._RX_BUF_SZ = 1024
+        self._RX_BUF_SZ = 2048
         self._sock = None
         self.is_connected = False
 


### PR DESCRIPTION
Ignore issues when unicode decoding received strings and split received messages into chunks seperated by \r\n.

 May need update to build a full message if one is received in multiple chunks but so far no such problems encountered.